### PR TITLE
Fix project build from terminal 

### DIFF
--- a/coolstore/pom.xml
+++ b/coolstore/pom.xml
@@ -30,7 +30,7 @@
       <plugin>
         <groupId>org.kie</groupId>
         <artifactId>kie-maven-plugin</artifactId>
-        <version>6.4.0.Final-redhat-3</version>
+        <version>${version.org.kie}</version>
         <extensions>true</extensions>
       </plugin>
     </plugins>

--- a/coolstore/pom.xml
+++ b/coolstore/pom.xml
@@ -7,6 +7,17 @@
   <version>2.0.0</version>
   <packaging>kjar</packaging>
   <name>coolstore</name>
+  <properties>
+    <version.org.kie>6.4.0.Final-redhat-3</version.org.kie>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-api</artifactId>
+      <version>${version.org.kie}</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
   <repositories>
     <repository>
       <id>guvnor-m2-repo</id>

--- a/coolstore/pom.xml
+++ b/coolstore/pom.xml
@@ -19,7 +19,7 @@
       <plugin>
         <groupId>org.kie</groupId>
         <artifactId>kie-maven-plugin</artifactId>
-        <version>6.3.0.Final-redhat-4</version>
+        <version>6.4.0.Final-redhat-3</version>
         <extensions>true</extensions>
       </plugin>
     </plugins>


### PR DESCRIPTION
This fix allows the project to be build in a terminal using standard Maven. We added a required dependency to "kie-api".
