### PR TITLE
Added stateless kie session configuration.

### DIFF
--- a/coolstore/src/main/resources/META-INF/kmodule.xml
+++ b/coolstore/src/main/resources/META-INF/kmodule.xml
@@ -1,1 +1,5 @@
-<kmodule xmlns="http://jboss.org/kie/6.0.0/kmodule" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+<kmodule xmlns="http://jboss.org/kie/6.0.0/kmodule" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <kbase name="coolstore-kie-base" default="true" eventProcessingMode="cloud" equalsBehavior="equality">
+    <ksession name="coolstore-kie-session" type="stateless" default="true" clockType="realtime"/>
+  </kbase>
+</kmodule>


### PR DESCRIPTION
Coolstore rules need to run in a stateless kie-session. Configuration for such a session has been added to kmodule.xml.
